### PR TITLE
fix agent info not showing on delete agent modal and core memory

### DIFF
--- a/src/app/(server)/api/agents/helpers.ts
+++ b/src/app/(server)/api/agents/helpers.ts
@@ -13,7 +13,7 @@ export async function validateAgentOwner(
     return {
       userId: 'default',
       agentId,
-      agent: getAgent(agentId)
+      agent: await getAgent(agentId)
     }
   }
 


### PR DESCRIPTION
The error happened because `getAgent()` is an async function, so we need an `await` to go with it.