### PR TITLE
fix: remove invalid isEnabled prop from DOM element

### DIFF
--- a/src/components/ui/reasoning-message.tsx
+++ b/src/components/ui/reasoning-message.tsx
@@ -11,7 +11,6 @@ const ReasoningMessageBlock = (props: ReasoningMessageProps) => {
 
   return (
     <div
-      {...props}
       className={`flex w-max max-w-[100%] px-3 py-2 text-sm ${!isEnabled && 'hidden'}`}
     >
       <LeftBar />


### PR DESCRIPTION
Remove {...props} spread operator from ReasoningMessageBlock div to prevent React warning about unrecognized DOM props. The isEnabled prop is now only used for conditional styling as intended.